### PR TITLE
Fixed time_mosq.c

### DIFF
--- a/libmosquitto/time_mosq.c
+++ b/libmosquitto/time_mosq.c
@@ -85,7 +85,7 @@ time_t mosquitto_time(void)
 	if(tb.denom == 0){
 		mach_timebase_info(&tb);
 	}
-	sec = (ticks/1000000000)*(tb.numer/tb.denom);
+	sec = (ticks*(tb.numer/tb.denom))/1000000000;
 
 	return (time_t)sec;
 #else


### PR DESCRIPTION
Dear Michael Woytowich,

I have a test in iPhone6Plus, we found a problem.

In iPhone6Plus,

tb.numer = 125
tb.denom = 3

So, the value of sec is truncated, keepalive did not work correctly.
We changed the formula of sec.

Best regards,

MTattin
